### PR TITLE
feat: add database creation and paper processing commands to CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+examples/data/
+outputs/

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,16 @@
+# Create the database with default output location
+```bash
+python src/main.py create-database
+```
+
+
+# Create the database with custom output location
+```bash
+python src/main.py create-database --output /path/to/output.json
+```
+
+
+# Process a paper (placeholder functionality)
+```bash
+python src/main.py process-paper --input /path/to/paper.pdf --output /path/to/output/dir
+```

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,104 @@
+# src/main.py
+import argparse
+import sys
+from pathlib import Path
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Paper2Code - Transform academic papers into functional code')
+
+    subparsers = parser.add_subparsers(dest='command', help='Available commands')
+
+    # Create the database parser
+    db_parser = subparsers.add_parser('create-database', help='Create software database from repository data')
+    db_parser.add_argument('--output', type=str, help='Output file path for the database')
+
+    # Add parser for paper processing (placeholder for future functionality)
+    paper_parser = subparsers.add_parser('process-paper', help='Process academic paper')
+    paper_parser.add_argument('--input', type=str, required=True, help='Input paper file path')
+    paper_parser.add_argument('--output', type=str, help='Output directory for generated code')
+
+    return parser.parse_args()
+
+
+def read_file_content(file_path: Path) -> str:
+    """Read content from a file."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return f.read()
+    except Exception as e:
+        print(f"Error reading file {file_path}: {e}")
+        return ""
+
+
+def handle_database_creation(output_file: str = None) -> None:
+    """Handle the database creation command."""
+    from utils.database_creator import create_software_database
+
+    # Get the project root directory
+    script_dir = Path(__file__).resolve().parent
+    project_root = script_dir.parent
+
+    # Define input and output files
+    data_dir = project_root / "examples" / "data"
+    pypi_file = data_dir / "pypi_20241103_154558.json"
+    conda_file = data_dir / "conda-forge_20241103_154558.json"
+    bioconductor_file = data_dir / "bioconductor_20241103_154558.json"
+
+    # Use provided output file or default
+    if not output_file:
+        output_dir = script_dir / "outputs"
+        output_file = str(output_dir / "software_database.json")
+
+    # Verify that input files exist
+    if not all(f.exists() for f in [pypi_file, conda_file, bioconductor_file]):
+        print("\nInput files not found. Checking paths:")
+        for file_path in [pypi_file, conda_file, bioconductor_file]:
+            print(f"{'✓' if file_path.exists() else '✗'} {file_path}")
+        sys.exit(1)
+
+    # Read repository data
+    print("Reading repository data...")
+    pypi_data = read_file_content(pypi_file)
+    conda_data = read_file_content(conda_file)
+    bioconductor_data = read_file_content(bioconductor_file)
+
+    if not any([pypi_data, conda_data, bioconductor_data]):
+        print("Error: No repository data could be read.")
+        sys.exit(1)
+
+    print("Creating software database...")
+    try:
+        create_software_database(
+            pypi_data=pypi_data,
+            conda_data=conda_data,
+            bioconductor_data=bioconductor_data,
+            output_file=output_file
+        )
+        print("\nDatabase creation completed successfully!")
+    except Exception as e:
+        print(f"Error creating database: {e}")
+        sys.exit(1)
+
+
+def handle_paper_processing(input_file: str, output_dir: str = None) -> None:
+    """Handle the paper processing command (placeholder)."""
+    print(f"Paper processing functionality will be implemented here.")
+    print(f"Input file: {input_file}")
+    print(f"Output directory: {output_dir}")
+
+
+def main():
+    args = parse_arguments()
+
+    if args.command == 'create-database':
+        handle_database_creation(args.output)
+    elif args.command == 'process-paper':
+        handle_paper_processing(args.input, args.output)
+    else:
+        print("Please specify a command. Use --help for more information.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/database_creator.py
+++ b/src/utils/database_creator.py
@@ -1,0 +1,119 @@
+import json
+from pathlib import Path
+from typing import Dict, List, Union
+
+
+class SoftwareDatabaseCreator:
+    def __init__(self):
+        self.database: Dict[str, Dict[str, Union[List[str], List[str]]]] = {}
+
+    def process_repository_data(self, data: List[Dict], repository_name: str) -> None:
+        """Process software data from a repository and add it to the database."""
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+
+            name = item.get('name')
+            versions = item.get('versions')
+
+            if not name:
+                continue
+
+            if name not in self.database:
+                self.database[name] = {
+                    'versions': set(),
+                    'repositories': set()
+                }
+
+            if versions:
+                if isinstance(versions, list):
+                    self.database[name]['versions'].update(versions)
+                elif isinstance(versions, str):
+                    self.database[name]['versions'].add(versions)
+
+            self.database[name]['repositories'].add(repository_name)
+
+    def format_database(self) -> Dict[str, Dict[str, Union[List[str], List[str]]]]:
+        """Convert sets to sorted lists for JSON serialization."""
+        formatted_db = {}
+        for name, info in self.database.items():
+            formatted_db[name] = {
+                'versions': sorted(list(info['versions'])) if info['versions'] else None,
+                'repositories': sorted(list(info['repositories']))
+            }
+        return formatted_db
+
+    def save_database(self, output_file: str = 'software_database.json') -> None:
+        """Save the formatted database to a JSON file."""
+        formatted_db = self.format_database()
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(output_file, 'w', encoding='utf-8') as f:
+            json.dump(formatted_db, f, indent=2, sort_keys=True)
+        print(f"Database saved to {output_file}")
+
+    def get_statistics(self) -> Dict[str, int]:
+        """Get basic statistics about the database."""
+        formatted_db = self.format_database()
+        stats = {
+            'total_packages': len(formatted_db),
+            'packages_with_versions': len([pkg for pkg in formatted_db.values() if pkg['versions']]),
+            'multi_repo_packages': len([pkg for pkg in formatted_db.values() if len(pkg['repositories']) > 1])
+        }
+        return stats
+
+    @staticmethod
+    def load_json_data(json_str: str) -> List[Dict]:
+        """Load JSON data from a string."""
+        try:
+            return json.loads(json_str)
+        except json.JSONDecodeError as e:
+            print(f"Error parsing JSON: {e}")
+            return []
+
+
+def create_software_database(pypi_data: str, conda_data: str, bioconductor_data: str,
+                           output_file: str = 'software_database.json') -> None:
+    """
+    Create a software database from multiple repository data sources.
+
+    Args:
+        pypi_data: JSON string containing PyPI package data
+        conda_data: JSON string containing Conda Forge package data
+        bioconductor_data: JSON string containing Bioconductor package data
+        output_file: Path to save the resulting database
+    """
+    # Initialize database creator
+    db_creator = SoftwareDatabaseCreator()
+
+    # Process each repository
+    repositories_data = [
+        (pypi_data, 'pypi'),
+        (conda_data, 'conda-forge'),
+        (bioconductor_data, 'bioconductor')
+    ]
+
+    for data_str, repo_name in repositories_data:
+        data = db_creator.load_json_data(data_str)
+        if data:
+            db_creator.process_repository_data(data, repo_name)
+        else:
+            print(f"Warning: No data processed for {repo_name}")
+
+    # Save the database
+    db_creator.save_database(output_file)
+
+    # Print statistics
+    stats = db_creator.get_statistics()
+    print("\nDatabase Statistics:")
+    print(f"Total unique packages: {stats['total_packages']}")
+    print(f"Packages with version information: {stats['packages_with_versions']}")
+    print(f"Packages in multiple repositories: {stats['multi_repo_packages']}")
+
+    # Print sample entries
+    print("\nSample entries:")
+    formatted_db = db_creator.format_database()
+    for name in list(formatted_db.keys())[:3]:
+        print(f"\n{name}:")
+        print(json.dumps(formatted_db[name], indent=2))


### PR DESCRIPTION
- Updated `.gitignore` to include `examples/data/` and `outputs/`
- Added `USAGE.md` with usage examples for database creation and paper processing commands
- Implemented CLI in `src/main.py`:
  - `create-database` command to generate a software database from input files with optional output location
  - `process-paper` command (placeholder for future functionality) with input and output options
- Added `SoftwareDatabaseCreator` class in `src/utils/database_creator.py`:
  - Processes and aggregates data from multiple sources (PyPI, Conda, Bioconductor)
  - Outputs to JSON and provides basic database statistics